### PR TITLE
Add PR URL to "git publish" workflow

### DIFF
--- a/bin/github-pr-url
+++ b/bin/github-pr-url
@@ -1,11 +1,14 @@
 #!/bin/sh
 
+# If in a Git repository
 if [ -d .git ] || git rev-parse --git-dir &> /dev/null; then
   remote=${1-origin}
   url=$(git remote get-url "$remote")
 
+  # If $remote points to a GitHub-backed repo
   if echo "$url" | grep "github.com" &> /dev/null; then
     # If using GNU sed, replace `-E` with `-r` on the next line
+    # Get the GitHub `owner/name` pair from the remote URL
     nwo=$(echo "$url" | sed -E "s/^[^:]+:([^/]+\/[^.]+).git$/\1/")
     branch=$(git rev-parse --abbrev-ref HEAD)
 

--- a/bin/github-pr-url
+++ b/bin/github-pr-url
@@ -5,6 +5,7 @@ if [ -d .git ] || git rev-parse --git-dir &> /dev/null; then
   url=$(git remote get-url "$remote")
 
   if echo "$url" | grep "github.com" &> /dev/null; then
+    # If using GNU sed, replace `-E` with `-r` on the next line
     nwo=$(echo "$url" | sed -E "s/^[^:]+:([^/]+\/[^.]+).git$/\1/")
     branch=$(git rev-parse --abbrev-ref HEAD)
 

--- a/bin/github-pr-url
+++ b/bin/github-pr-url
@@ -1,0 +1,13 @@
+#!/bin/sh
+
+if [ -e "./.git" ]; then
+  remote=${1-origin}
+  url=$(git remote get-url "$remote")
+
+  if echo "$url" | grep "github.com" &> /dev/null; then
+    nwo=$(echo "$url" | sed -E "s/^[^:]+:([^/]+\/[^.]+).git$/\1/")
+    branch=$(git rev-parse --abbrev-ref HEAD)
+
+    echo "Submit PR: https://github.com/$nwo/pull/new/$branch"
+  fi
+fi

--- a/bin/github-pr-url
+++ b/bin/github-pr-url
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-if [ -e "./.git" ]; then
+if [ -d .git ] || git rev-parse --git-dir &> /dev/null; then
   remote=${1-origin}
   url=$(git remote get-url "$remote")
 

--- a/gitconfig
+++ b/gitconfig
@@ -29,7 +29,7 @@
   branch-name = "!git rev-parse --abbrev-ref HEAD"
   # Push the current branch to the remote "origin", and set it to track
   # the upstream branch
-  publish = "!git push -u origin $(git branch-name)"
+  publish = !sh -c 'git push -u origin $(git branch-name) && github-pr-url' -
   # Delete the remote version of the current branch
   unpublish = "!git push origin :$(git branch-name)"
 

--- a/gitconfig
+++ b/gitconfig
@@ -24,12 +24,18 @@
 
   ### Long names for pseudo-commands ###
 
+  # Returns true if in a Git repo; false otherwise
+  in-repo = !sh -c '[ -d .git ] || git rev-parse --git-dir &> /dev/null' -
+
   # Get the current branch name (not so useful in itself, but used in
   # other aliases)
   branch-name = "!git rev-parse --abbrev-ref HEAD"
-  # Push the current branch to the remote "origin", and set it to track
-  # the upstream branch
+
+  # Push the current branch to the remote "origin", set it to track
+  # the upstream branch, and display the URL to use to submit a PR if in a
+  # GitHub-backed repository
   publish = !sh -c 'git push -u origin $(git branch-name) && github-pr-url' -
+
   # Delete the remote version of the current branch
   unpublish = "!git push origin :$(git branch-name)"
 


### PR DESCRIPTION
Inspired by [a topic on the GitHub Community Forum](https://github.community/t5/How-to-use-Git-and-GitHub/Feature-GitHub-post-receive-message-on-push/m-p/4578#M1493)

The script `bin/github-pr-url` will figure out the URL to use to submit a PR for the current branch if the given remote (`origin` by default) is a github.com remote. If this is intended to be used on a Unix-based platform other than macOS, the first parameter to `sed` on line 8 may need to be changed from `-E` to `-r` if GNU `sed` is being used.

The script can be run standalone or integrated into other workflow helpers like I did in the `gitconfig`. Now my `git publish` workflow publishes the current branch to the `origin` remote and then gives a link to open a PR for that branch.

Sample output (used to publish this PR):

```
$ git publish
Counting objects: 7, done.
Delta compression using up to 8 threads.
Compressing objects: 100% (7/7), done.
Writing objects: 100% (7/7), 2.23 KiB | 2.23 MiB/s, done.
Total 7 (delta 4), reused 0 (delta 0)
remote: Resolving deltas: 100% (4/4), completed with 3 local objects.
To github.com:lee-dohm/dotfiles.git
 * [new branch]      github-pr-url -> github-pr-url
Branch 'github-pr-url' set up to track remote branch 'github-pr-url' from 'origin'.
Submit PR: https://github.com/lee-dohm/dotfiles/pull/new/github-pr-url
```